### PR TITLE
Add basic nextSong, and prevSong functionality 

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -11,7 +11,7 @@ songs *currSong;
 int setupMA() {
   result = ma_engine_init(NULL, &engine);
 
-  if (result != MA_SUCCESS) {
+  if (MA_SUCCESS != result) {
     cleanupMA();
     return -1;
   }
@@ -22,13 +22,13 @@ int setupMA() {
 void loadSound(ITEM *item) {
   songs *song;
   for (song = songList; NULL != song; song = song->next) {
-    if ((strcmp(item->description.str, song->title) == 0))
-      if ((strcmp(item->name.str, song->artist) == 0)) {
+    if (0 == (strcmp(item->description.str, song->title)))
+      if (0 == (strcmp(item->name.str, song->artist))) {
         currSong = song;
       }
   }
 
-  if (currSong == NULL)
+  if (NULL == currSong)
     return;
 
   ma_sound_uninit(&sound);
@@ -40,25 +40,25 @@ void toggleSong() {
   ma_sound_is_playing(&sound) ? ma_sound_stop(&sound) : ma_sound_start(&sound);
 }
 
-bool isPlaying() {
-  return ma_sound_is_playing(&sound);
-}
+bool isPlaying() { return ma_sound_is_playing(&sound); }
 
-void nextSong() {
-  if (currSong == NULL || currSong->next == NULL)
+void playNextSong() {
+  if (NULL == currSong || NULL == currSong->next)
     return;
   currSong = currSong->next;
-  fprintf(log_file, "currSong = %s, currSong->prev = %s\n", currSong->title, currSong->prev->title);
+  fprintf(log_file, "currSong = %s, currSong->prev = %s\n", currSong->title,
+          currSong->prev->title);
   ma_sound_uninit(&sound);
   ma_sound_init_from_file(&engine, currSong->path, 0, NULL, NULL, &sound);
   ma_sound_start(&sound);
 }
 
-void prevSong() {
-  if (currSong == NULL || NULL == currSong->prev)
+void playPrevSong() {
+  if (NULL == currSong || NULL == currSong->prev)
     return;
   currSong = currSong->prev;
-  fprintf(log_file, "currSong = %s, currSong->next = %s\n", currSong->title, currSong->next->title);
+  fprintf(log_file, "currSong = %s, currSong->next = %s\n", currSong->title,
+          currSong->next->title);
   ma_sound_uninit(&sound);
   ma_sound_init_from_file(&engine, currSong->path, 0, NULL, NULL, &sound);
   ma_sound_start(&sound);
@@ -75,7 +75,7 @@ void restartSong() { ma_sound_seek_to_pcm_frame(&sound, 0); }
 int getSongTime() {
   float pCursor;
   result = ma_sound_get_cursor_in_seconds(&sound, &pCursor);
-  if (result != MA_SUCCESS) {
+  if (MA_SUCCESS != result) {
     return 0;
   }
   return (int)(pCursor);

--- a/audio.c
+++ b/audio.c
@@ -6,6 +6,7 @@ ma_result result;
 ma_engine engine;
 ma_resource_manager rm;
 ma_sound sound;
+songs *currSong;
 
 int setupMA() {
   result = ma_engine_init(NULL, &engine);
@@ -20,18 +21,18 @@ int setupMA() {
 
 void loadSound(ITEM *item) {
   songs *song;
-  char *path;
   for (song = songList; NULL != song; song = song->next) {
     if ((strcmp(item->description.str, song->title) == 0))
-      if ((strcmp(item->name.str, song->artist) == 0))
-        path = song->path;
+      if ((strcmp(item->name.str, song->artist) == 0)) {
+        currSong = song;
+      }
   }
 
-  if (path == NULL)
+  if (currSong == NULL)
     return;
 
   ma_sound_uninit(&sound);
-  ma_sound_init_from_file(&engine, path, 0, NULL, NULL, &sound);
+  ma_sound_init_from_file(&engine, currSong->path, 0, NULL, NULL, &sound);
   ma_sound_start(&sound);
 }
 
@@ -41,6 +42,26 @@ void toggleSong() {
 
 bool isPlaying() {
   return ma_sound_is_playing(&sound);
+}
+
+void nextSong() {
+  if (currSong == NULL || currSong->next == NULL)
+    return;
+  currSong = currSong->next;
+  fprintf(log_file, "currSong = %s, currSong->prev = %s\n", currSong->title, currSong->prev->title);
+  ma_sound_uninit(&sound);
+  ma_sound_init_from_file(&engine, currSong->path, 0, NULL, NULL, &sound);
+  ma_sound_start(&sound);
+}
+
+void prevSong() {
+  if (currSong == NULL || NULL == currSong->prev)
+    return;
+  currSong = currSong->prev;
+  fprintf(log_file, "currSong = %s, currSong->next = %s\n", currSong->title, currSong->next->title);
+  ma_sound_uninit(&sound);
+  ma_sound_init_from_file(&engine, currSong->path, 0, NULL, NULL, &sound);
+  ma_sound_start(&sound);
 }
 
 int getSongDuration() {

--- a/directory.c
+++ b/directory.c
@@ -5,19 +5,20 @@ TagLib_File *file;
 TagLib_Tag *tag;
 
 int parseDirectory(const char *path, const struct stat *sptr, int type) {
-  if (type == FTW_F && strstr(path, ".mp3")) {
+  if (FTW_F == type && strstr(path, ".mp3")) {
     insertSongNode(&songList, (char *)path);
   }
   return 0;
 }
 
 void populateSongItems() {
-  if (songList == NULL)
+  if (NULL == songList)
     return;
-  for (songs *song = songList; song != NULL; song = song->next) {
-    fprintf(log_file, "songList[%d] %s, %s, %s\n",n_songs, song->artist, song->title, song->path);
+  for (songs *song = songList; NULL != song; song = song->next) {
+    fprintf(log_file, "songList[%d] %s, %s, %s\n", n_songs, song->artist,
+            song->title, song->path);
     ITEM *n_item = new_item(song->artist, song->title);
-    if (n_item == NULL)
+    if (NULL == n_item)
       continue;
     song_items[n_songs] = n_item;
     // memcpy(song_items[n_songs], &n_item, sizeof(ITEM));
@@ -35,7 +36,7 @@ void logSongList(void) {
 int setupDir(char *dirPath) {
   songList = NULL;
   ftw(dirPath, parseDirectory, 7);
-  if (songList == NULL) {
+  if (NULL == songList) {
     return -1;
   }
   return 0;
@@ -51,7 +52,7 @@ void insertSongNode(songs **songList, char *path) {
     strcpy(newNode->album, taglib_tag_album(tag));
     strcpy(newNode->path, path);
     newNode->next = NULL;
-    if (*songList == NULL) {
+    if (NULL == *songList) {
       *songList = newNode;
       newNode->prev = NULL;
       return;
@@ -59,7 +60,7 @@ void insertSongNode(songs **songList, char *path) {
 
     songs *temp = *songList;
 
-    while(temp->next!=NULL)
+    while (NULL != temp->next)
       temp = temp->next;
 
     temp->next = newNode;
@@ -68,4 +69,3 @@ void insertSongNode(songs **songList, char *path) {
     taglib_file_free(file);
   }
 }
-

--- a/directory.c
+++ b/directory.c
@@ -6,7 +6,7 @@ TagLib_Tag *tag;
 
 int parseDirectory(const char *path, const struct stat *sptr, int type) {
   if (type == FTW_F && strstr(path, ".mp3")) {
-    songList = parseAudioFile(songList, (char *)path);
+    insertSongNode(&songList, (char *)path);
   }
   return 0;
 }
@@ -33,34 +33,39 @@ void logSongList(void) {
 }
 
 int setupDir(char *dirPath) {
+  songList = NULL;
   ftw(dirPath, parseDirectory, 7);
   if (songList == NULL) {
-    fprintf(stdout, "%s", songList);
     return -1;
   }
   return 0;
 }
 
-songs *newSongNode(char *path) {
-  songs *newSong = malloc(sizeof(songs));
-  if (NULL != newSong) {
+void insertSongNode(songs **songList, char *path) {
+  songs *newNode = malloc(sizeof(songs));
+  if (NULL != newNode) {
     file = taglib_file_new(path);
     tag = taglib_file_tag(file);
-    strcpy(newSong->artist, taglib_tag_artist(tag));
-    strcpy(newSong->title, taglib_tag_title(tag));
-    strcpy(newSong->album, taglib_tag_album(tag));
-    strcpy(newSong->path, path);
-    newSong->next = NULL;
+    strcpy(newNode->artist, taglib_tag_artist(tag));
+    strcpy(newNode->title, taglib_tag_title(tag));
+    strcpy(newNode->album, taglib_tag_album(tag));
+    strcpy(newNode->path, path);
+    newNode->next = NULL;
+    if (*songList == NULL) {
+      *songList = newNode;
+      newNode->prev = NULL;
+      return;
+    }
+
+    songs *temp = *songList;
+
+    while(temp->next!=NULL)
+      temp = temp->next;
+
+    temp->next = newNode;
+    newNode->prev = temp;
     taglib_tag_free_strings();
     taglib_file_free(file);
   }
-  return newSong;
 }
 
-songs *parseAudioFile(songs *songList, char *path) {
-  songs *newSong = newSongNode(path);
-  if (NULL != newSong) {
-    newSong->next = songList;
-  }
-  return newSong;
-}

--- a/main.c
+++ b/main.c
@@ -8,20 +8,20 @@ int main(int argc, char **argv) {
   }
   log_file = fopen("wax.log", "a+");
   ret = setupDir(argv[1]);
-  if (ret != 0) {
+  if (0 != ret) {
     fprintf(stderr, "failed to load directory %s", argv[1]);
     fclose(log_file);
     return -1;
   }
   ret = setupMA();
-  if (ret != 0) {
+  if (0 != ret) {
     fprintf(stderr, "failed to load audio engine");
     fclose(log_file);
     return -1;
   }
 
   ret = setupUI();
-  if (ret != 0) {
+  if (0 != ret) {
     fprintf(stderr, "failed to load ncurses UI");
     fclose(log_file);
     return -1;

--- a/menu.c
+++ b/menu.c
@@ -20,14 +20,14 @@ void printMiddle(WINDOW *win, int starty, int startx, int width, char *string,
   int length, x, y;
   int temp;
 
-  if (win == NULL)
+  if (NULL == win)
     win = stdscr;
   getyx(win, y, x);
-  if (startx != 0)
+  if (0 != startx)
     x = startx;
-  if (starty != 0)
+  if (0 != starty)
     y = starty;
-  if (width == 0)
+  if (0 == width)
     width = 80;
 
   length = strlen(string);

--- a/ui.c
+++ b/ui.c
@@ -1,3 +1,4 @@
+#include "ncurses.h"
 #include "wax.h"
 
 ITEM **song_items;
@@ -51,9 +52,9 @@ int setupUI() {
   post_menu(song_menu);
   wrefresh(song_win);
 
-  while ((ch = getch()) != 'q') {
+  while ('q' != (ch = getch())) {
     int currSecs = getSongTime();
-    mvprintw(1, COLS - 10, "%d:%d", (currSecs/60)%60, currSecs%60);
+    mvprintw(1, COLS - 10, "%d:%d", (currSecs / 60) % 60, currSecs % 60);
     handleInput(ch);
   }
   return 0;
@@ -70,6 +71,7 @@ void handleInput(int ch) {
     menu_driver(song_menu, REQ_UP_ITEM);
     break;
   case '>':
+  case KEY_RIGHT:
     menu_driver(song_menu, REQ_DOWN_ITEM);
     for (int i = 1; i < COLS - 1; i++) {
       mvprintw(1, i, " ");
@@ -80,9 +82,10 @@ void handleInput(int ch) {
                 strlen(getCurrTitle(song_menu->curitem->index)),
                 getCurrTitle(song_menu->curitem->index), 1);
     refresh();
-    nextSong();
+    playNextSong();
     break;
   case '<':
+  case KEY_LEFT:
     menu_driver(song_menu, REQ_UP_ITEM);
     for (int i = 1; i < COLS - 1; i++) {
       mvprintw(1, i, " ");
@@ -93,7 +96,7 @@ void handleInput(int ch) {
                 strlen(getCurrTitle(song_menu->curitem->index)),
                 getCurrTitle(song_menu->curitem->index), 1);
     refresh();
-    prevSong();
+    playPrevSong();
     break;
   case ' ':
     toggleSong();
@@ -118,7 +121,8 @@ void handleInput(int ch) {
                 getCurrTitle(song_menu->curitem->index), 1);
     loadSound(song_menu->curitem);
     int seconds = getSongDuration();
-    mvwprintw(song_win, 1, COLS - 5, "%d:%d", (seconds/60)%60, seconds%60);
+    mvwprintw(song_win, 1, COLS - 5, "%d:%d", (seconds / 60) % 60,
+              seconds % 60);
     refresh();
     break;
   }

--- a/ui.c
+++ b/ui.c
@@ -51,8 +51,9 @@ int setupUI() {
   post_menu(song_menu);
   wrefresh(song_win);
 
-  while ((ch = getch()) != KEY_F(1)) {
-    mvprintw(1, COLS - 7, "%d", getSongTime());
+  while ((ch = getch()) != 'q') {
+    int currSecs = getSongTime();
+    mvprintw(1, COLS - 10, "%d:%d", (currSecs/60)%60, currSecs%60);
     handleInput(ch);
   }
   return 0;
@@ -67,6 +68,32 @@ void handleInput(int ch) {
   case 'k':
   case KEY_UP:
     menu_driver(song_menu, REQ_UP_ITEM);
+    break;
+  case '>':
+    menu_driver(song_menu, REQ_DOWN_ITEM);
+    for (int i = 1; i < COLS - 1; i++) {
+      mvprintw(1, i, " ");
+    }
+    printMiddle(song_win, 1,
+                (COLS / 2) -
+                    (strlen(getCurrTitle(song_menu->curitem->index)) / 2),
+                strlen(getCurrTitle(song_menu->curitem->index)),
+                getCurrTitle(song_menu->curitem->index), 1);
+    refresh();
+    nextSong();
+    break;
+  case '<':
+    menu_driver(song_menu, REQ_UP_ITEM);
+    for (int i = 1; i < COLS - 1; i++) {
+      mvprintw(1, i, " ");
+    }
+    printMiddle(song_win, 1,
+                (COLS / 2) -
+                    (strlen(getCurrTitle(song_menu->curitem->index)) / 2),
+                strlen(getCurrTitle(song_menu->curitem->index)),
+                getCurrTitle(song_menu->curitem->index), 1);
+    refresh();
+    prevSong();
     break;
   case ' ':
     toggleSong();
@@ -90,7 +117,8 @@ void handleInput(int ch) {
                 strlen(getCurrTitle(song_menu->curitem->index)),
                 getCurrTitle(song_menu->curitem->index), 1);
     loadSound(song_menu->curitem);
-    mvwprintw(song_win, 1, COLS - 4, "%d", getSongDuration());
+    int seconds = getSongDuration();
+    mvwprintw(song_win, 1, COLS - 5, "%d:%d", (seconds/60)%60, seconds%60);
     refresh();
     break;
   }

--- a/wax.h
+++ b/wax.h
@@ -42,8 +42,8 @@ int setupDir(char *dirPath);
 /* Load song into engine and play it, stopping any currently playing song */
 void loadSound(ITEM *item);
 
-void nextSong();
-void prevSong();
+void playNextSong();
+void playPrevSong();
 
 int getSongTime();
 

--- a/wax.h
+++ b/wax.h
@@ -16,6 +16,7 @@ typedef struct song_file {
   char artist[200];
   char title[200];
   char album[200];
+  struct song_file *prev;
   struct song_file *next;
 } songs;
 
@@ -26,8 +27,8 @@ extern FILE *log_file;
 songs *newSongNode(char *path);
 
 /* parse audiofile and return a songList with that file as the new head node */
-songs *parseAudioFile(songs *songList, char *path);
 
+void insertSongNode(songs **songList, char *path);
 int getSongDuration();
 void handle_winch(int sig);
 /* Teardown the audio engine */
@@ -40,6 +41,9 @@ void cleanupUI();
 int setupDir(char *dirPath);
 /* Load song into engine and play it, stopping any currently playing song */
 void loadSound(ITEM *item);
+
+void nextSong();
+void prevSong();
 
 int getSongTime();
 


### PR DESCRIPTION
Changed how songs are organized on the backend.

Switched the 'quit' button to 'q'

Copied our display song title block of logic to be run when skipping forward and background songs to keep the display fresh.